### PR TITLE
Fix javascript function name generation

### DIFF
--- a/servant-js.cabal
+++ b/servant-js.cabal
@@ -93,4 +93,5 @@ test-suite spec
                    , servant
                    , servant-js
                    , text
+                   , QuickCheck
   default-language:  Haskell2010

--- a/src/Servant/JS/Angular.hs
+++ b/src/Servant/JS/Angular.hs
@@ -132,7 +132,7 @@ generateAngularJSWith ngOptions opts req = "\n" <>
 
         fsep = if hasService then ":" else " ="
 
-        fname = namespace <> (functionNameBuilder opts $ req ^. reqFuncName)
+        fname = namespace <> (toValidFunctionName (functionNameBuilder opts $ req ^. reqFuncName))
 
         method = req ^. reqMethod
         url = if url' == "'" then "'/'" else url'

--- a/src/Servant/JS/Axios.hs
+++ b/src/Servant/JS/Axios.hs
@@ -120,7 +120,7 @@ generateAxiosJSWith aopts opts req = "\n" <>
                where
                   hasNoModule = moduleName opts == ""
 
-        fname = namespace <> (functionNameBuilder opts $ req ^. reqFuncName)
+        fname = namespace <> (toValidFunctionName (functionNameBuilder opts $ req ^. reqFuncName))
 
         method = T.toLower . decodeUtf8 $ req ^. reqMethod
         url = if url' == "'" then "'/'" else url'

--- a/src/Servant/JS/Internal.hs
+++ b/src/Servant/JS/Internal.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE ViewPatterns #-}
 
 module Servant.JS.Internal
   ( JavaScriptGenerator
@@ -116,12 +115,11 @@ toValidFunctionName t =
       setFirstChar x `T.cons` T.filter remainder xs
     Nothing -> "_"
   where
-    setFirstChar c = if firstChar c then c else '_'
-    firstChar c = prefixOK c || Set.member c firstLetterOK
-    remainder c = prefixOK c || Set.member c remainderOK
-    prefixOK c = c `elem` ['$','_']
+    setFirstChar c = if Set.member c firstLetterOK then c else '_'
+    remainder c = Set.member c remainderOK
     firstLetterOK = (filterBmpChars $ mconcat
-                      [ Set.lowercaseLetter
+                      [ Set.fromDistinctAscList "$_"
+                      , Set.lowercaseLetter
                       , Set.uppercaseLetter
                       , Set.titlecaseLetter
                       , Set.modifierLetter

--- a/src/Servant/JS/Internal.hs
+++ b/src/Servant/JS/Internal.hs
@@ -120,21 +120,27 @@ toValidFunctionName t =
     firstChar c = prefixOK c || Set.member c firstLetterOK
     remainder c = prefixOK c || Set.member c remainderOK
     prefixOK c = c `elem` ['$','_']
-    firstLetterOK = mconcat
+    firstLetterOK = (filterBmpChars $ mconcat
                       [ Set.lowercaseLetter
                       , Set.uppercaseLetter
                       , Set.titlecaseLetter
                       , Set.modifierLetter
                       , Set.otherLetter
                       , Set.letterNumber
-                      ]
+                      ])
     remainderOK   = firstLetterOK
-               <> mconcat
+               <> (filterBmpChars $ mconcat
                     [ Set.nonSpacingMark
                     , Set.spacingCombiningMark
                     , Set.decimalNumber
                     , Set.connectorPunctuation
-                    ]
+                    ])
+
+-- Javascript identifiers can only contain codepoints in the Basic Multilingual Plane
+-- that is, codepoints that can be encoded in UTF-16 without a surrogate pair (UCS-2)
+-- that is, codepoints that can fit in 16-bits, up to 0xffff (65535)
+filterBmpChars :: Set.CharSet -> Set.CharSet
+filterBmpChars = Set.filter (< '\65536')
 
 toJSHeader :: HeaderArg f -> Text
 toJSHeader (HeaderArg n)

--- a/src/Servant/JS/JQuery.hs
+++ b/src/Servant/JS/JQuery.hs
@@ -86,7 +86,7 @@ generateJQueryJSWith opts req = "\n" <>
         namespace = if (moduleName opts) == ""
                        then "var "
                        else (moduleName opts) <> "."
-        fname = namespace <> (functionNameBuilder opts $ req ^. reqFuncName)
+        fname = namespace <> (toValidFunctionName (functionNameBuilder opts $ req ^. reqFuncName))
 
         method = req ^. reqMethod
         url = if url' == "'" then "'/'" else url'

--- a/src/Servant/JS/Vanilla.hs
+++ b/src/Servant/JS/Vanilla.hs
@@ -97,7 +97,7 @@ generateVanillaJSWith opts req = "\n" <>
         namespace = if moduleName opts == ""
                        then "var "
                        else (moduleName opts) <> "."
-        fname = namespace <> (functionNameBuilder opts $ req ^. reqFuncName)
+        fname = namespace <> (toValidFunctionName (functionNameBuilder opts $ req ^. reqFuncName))
 
         method = req ^. reqMethod
         url = if url' == "'" then "'/'" else url'


### PR DESCRIPTION
same PR as https://github.com/haskell-servant/servant/pull/556
The 191 mentioned in the first commit message is https://github.com/haskell-servant/servant/issues/191
