### PR TITLE
Vanilla: remove invalid check of responseType

### DIFF
--- a/src/Servant/JS/Vanilla.hs
+++ b/src/Servant/JS/Vanilla.hs
@@ -40,7 +40,7 @@ generateVanillaJSWith opts req = "\n" <>
  <> "    if (xhr.readyState === 4) {\n"
  <> "      if (xhr.status === 204 || xhr.status === 205) {\n"
  <> "        " <> onSuccess <> "();\n"
- <> "      } else if (xhr.status >= 200 && xhr.status < 300 && xhr.responseType === 'json') {\n"
+ <> "      } else if (xhr.status >= 200 && xhr.status < 300) {\n"
  <> "        try { res = JSON.parse(xhr.responseText); } catch (e) { " <> onError <> "(e); }\n"
  <> "        if (res) " <> onSuccess <> "(res);\n"
  <> "      } else {\n"


### PR DESCRIPTION
Hi @phadej,

I am sorry, but my original PR https://github.com/haskell-servant/servant-js/pull/9 didn't fix the issue with vanilla js but made the situation worse. At least it doesn't work for me anymore.

According to the XmlHttpRequest docs one has to set responseType before the request! Then one can just use xhr.response which will be either null or a valid object. See https://github.com/minad/servant-js/commit/a9922ac83cfcee83aabf06599264b7b3c693523b for a version which uses responseType correctly. Unfortunately this doesn't seem to be widely supported yet.

It worked before since I had onSuccess at the wrong place, which you pointed out. But then I probably didn't test the corrected version. Now onError is called always since responseType never equals json.

I recommend to merge this fix which removes the invalid check.

Daniel