### PR TITLE
Implement HasForeign instance

### DIFF
--- a/servant-js.cabal
+++ b/servant-js.cabal
@@ -47,7 +47,7 @@ library
                      , base-compat     >= 0.9
                      , charset         >= 0.3
                      , lens            >= 4
-                     , servant-foreign >= 0.9 && <0.12
+                     , servant-foreign >= 0.11.2 && <0.12
                      , servant         >= 0.9 && <0.15
                      , text            >= 1.2  && < 1.3
 

--- a/servant-js.cabal
+++ b/servant-js.cabal
@@ -47,7 +47,7 @@ library
                      , base-compat     >= 0.9
                      , charset         >= 0.3
                      , lens            >= 4
-                     , servant-foreign >= 0.11.2 && <0.12
+                     , servant-foreign >= 0.9 && <0.12
                      , servant         >= 0.9 && <0.15
                      , text            >= 1.2  && < 1.3
 

--- a/src/Servant/JS/Vanilla.hs
+++ b/src/Servant/JS/Vanilla.hs
@@ -34,7 +34,7 @@ generateVanillaJSWith opts req = "\n" <>
  <> "  xhr.open('" <> decodeUtf8 method <> "', " <> url <> ", true);\n"
  <>    reqheaders
  <> "  xhr.setRequestHeader('Accept', 'application/json');\n"
- <> (if isJust (req ^. reqBody) then "  xhr.setRequestHeader('Content-Type', 'application/json');\n" else "")
+ <> (if isJust (req ^. reqBody) && (req ^. reqBodyIsJSON)  then "  xhr.setRequestHeader('Content-Type', 'application/json');\n" else "")
  <> "  xhr.onreadystatechange = function () {\n"
  <> "    var res = null;\n"
  <> "    if (xhr.readyState === 4) {\n"
@@ -79,7 +79,7 @@ generateVanillaJSWith opts req = "\n" <>
 
         dataBody =
           if isJust (req ^. reqBody)
-            then "JSON.stringify(body)"
+            then if (req ^. reqBodyIsJSON) then "JSON.stringify(body)" else "body"
             else "null"
 
 

--- a/src/Servant/JS/Vanilla.hs
+++ b/src/Servant/JS/Vanilla.hs
@@ -7,7 +7,7 @@ import           Data.Text (Text)
 import           Data.Text.Encoding (decodeUtf8)
 import qualified Data.Text as T
 import           Data.Monoid
-import           Servant.Foreign
+import           Servant.Foreign hiding (header)
 import           Servant.JS.Internal
 
 -- | Generate vanilla javascript functions to make AJAX requests
@@ -34,7 +34,7 @@ generateVanillaJSWith opts req = "\n" <>
  <> "  xhr.open('" <> decodeUtf8 method <> "', " <> url <> ", true);\n"
  <>    reqheaders
  <> "  xhr.setRequestHeader('Accept', 'application/json');\n"
- <> (if isJust (req ^. reqBody) && (req ^. reqBodyIsJSON)  then "  xhr.setRequestHeader('Content-Type', 'application/json');\n" else "")
+ <> (if isJust (req ^. reqBody) && (req ^. reqBodyContentType == ReqBodyJSON)  then "  xhr.setRequestHeader('Content-Type', 'application/json');\n" else "")
  <> "  xhr.onreadystatechange = function () {\n"
  <> "    var res = null;\n"
  <> "    if (xhr.readyState === 4) {\n"
@@ -79,7 +79,7 @@ generateVanillaJSWith opts req = "\n" <>
 
         dataBody =
           if isJust (req ^. reqBody)
-            then if (req ^. reqBodyIsJSON) then "JSON.stringify(body)" else "body"
+            then if (req ^. reqBodyContentType == ReqBodyJSON) then "JSON.stringify(body)" else "body"
             else "null"
 
 


### PR DESCRIPTION
This is three patches, to `servant-foreign`, `servant-multipart`, and `servant-js`.

https://github.com/haskell-servant/servant-multipart/compare/master...afcady:multipart-foreign?expand=1

https://github.com/haskell-servant/servant/compare/master...afcady:multipart-foreign?expand=1

https://github.com/haskell-servant/servant-js/compare/master...afcady:multipart-foreign?expand=1

The patch to `servant-foreign` adds a Boolean field to the `Req` type specifying whether the request body is JSON (as is currently assumed).  The patch to `servant-multipart` implements a HasForeign instance that sets this field to `False`.  The patch to `servant-js` changes the output of `vanillaJS` when the flag is false, so that `JSON.stringify()` does not get called on the body and the content-type is not set to JSON.

This address https://github.com/haskell-servant/servant-multipart/issues/5