### PR TITLE
Use serveDirectoryFileServer

### DIFF
--- a/examples/counter.hs
+++ b/examples/counter.hs
@@ -69,7 +69,7 @@ server counter = counterPlusOne counter     -- (+1) on the TVar
 -- the whole server, including static file serving
 server' :: TVar Counter -> Server TestApi'
 server' counter = server counter
-             :<|> serveDirectory www -- serve static files
+             :<|> serveDirectoryFileServer www -- serve static files
 
 runServer :: TVar Counter -- ^ shared variable for the counter
           -> Int          -- ^ port the server should listen on


### PR DESCRIPTION
Failed to build previously with:

```
examples/counter.hs:72:19: warning: [-Wdeprecations]
    In the use of ‘serveDirectory’
    (imported from Servant, but defined in Servant.Server.StaticFiles):
    Deprecated: "Use serveDirectoryFileServer instead"
   |
72 |              :<|> serveDirectory www -- serve static files
   |                   ^^^^^^^^^^^^^^

```