### PR TITLE
Bump base, lens, text, hspec* bounds

### DIFF
--- a/servant-js.cabal
+++ b/servant-js.cabal
@@ -50,13 +50,13 @@ library
                        Servant.JS.Internal
                        Servant.JS.JQuery
                        Servant.JS.Vanilla
-  build-depends:       base            >= 4.9     && <4.17
+  build-depends:       base            >= 4.9     && <4.18
                      , base-compat     >= 0.10.5  && <0.13
                      , charset         >= 0.3.7.1 && <0.4
-                     , lens            >= 4.17    && <5.2
+                     , lens            >= 4.17    && <5.3
                      , servant-foreign >= 0.15    && <0.16
                      , servant         >= 0.15    && <0.20
-                     , text            >= 1.2.3.0 && < 1.3
+                     , text            >= 1.2.3.0 && < 1.3 || >= 2.0 && < 2.1
 
   hs-source-dirs:      src
   default-language:    Haskell2010
@@ -93,10 +93,10 @@ test-suite spec
   other-modules:
       Servant.JSSpec
       Servant.JSSpec.CustomHeaders
-  build-tool-depends: hspec-discover:hspec-discover >=2.6.0 && <2.8
+  build-tool-depends: hspec-discover:hspec-discover >=2.6.0 && <2.11
   build-depends:     base
                    , base-compat
-                   , hspec >= 2.6.0 && <2.8
+                   , hspec >= 2.6.0 && <2.11
                    , hspec-expectations
                    , language-ecmascript >= 0.16
                    , lens


### PR DESCRIPTION
This bumps bounds in order to support GHC 9.4.

Related PR for servant: https://github.com/haskell-servant/servant/pull/1592

This library depends on language-ecmascript, which requires this PR https://github.com/jswebtools/language-ecmascript/pull/89

But as this is just relaxing bounds, I think it can be merged before the language-ecmascript one.