### PR TITLE
Update dependencies for GHC 9.10.1

### DIFF
--- a/servant-js.cabal
+++ b/servant-js.cabal
@@ -32,6 +32,7 @@ tested-with:
    || ==9.4.8
    || ==9.6.3
    || ==9.8.1
+   || ==9.10.1
 
 extra-source-files:
   include/*.h
@@ -53,10 +54,10 @@ library
                        Servant.JS.Internal
                        Servant.JS.JQuery
                        Servant.JS.Vanilla
-  build-depends:       base            >= 4.9     && <4.20
-                     , base-compat     >= 0.10.5  && <0.14
+  build-depends:       base            >= 4.9     && <4.21
+                     , base-compat     >= 0.10.5  && <0.15
                      , charset         >= 0.3.7.1 && <0.4
-                     , lens            >= 4.17    && <5.3
+                     , lens            >= 4.17    && <5.4
                      , servant-foreign >= 0.15    && <0.17
                      , servant         >= 0.15    && <0.21
                      , text            >= 1.2.3.0 && < 1.3 || >= 2.0 && < 2.2


### PR DESCRIPTION
I've run the test suite constraining to the new versions of each bumped dependency - to do this I had to use the git version of language-ecmascript with some `--allow-newer`s, and I've also made a PR to that to update its own dependencies: https://github.com/jswebtools/language-ecmascript/pull/91